### PR TITLE
feat: add get_people endpoint with filtered response

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A [Model Context Protocol](https://modelcontextprotocol.com/) server that provid
 | `get_framework_controls` | Get detailed security control requirements for a specific compliance framework. Returns the specific controls, their descriptions, implementation guidance, and current compliance status. Essential for understanding what security measures are required for each compliance standard.                     |
 | `get_controls`           | List all security controls across all frameworks in your Vanta account. Returns control names, descriptions, framework mappings, and current implementation status. Use this to see all available controls or to find a specific control ID for use with other tools.                                        |
 | `get_control_tests`      | Get all automated tests that validate a specific security control. Use this when you know a control ID and want to see which specific tests monitor compliance for that control. Returns test details, current status, and any failing entities for the control's tests.                                     |
+| `get_people`             | Returns a list of all people in your Vanta account. This includes employees, contractors, and other personnel who have access to your organization's systems and data. Use this to get information about team members for compliance and security management purposes.                                       |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ A [Model Context Protocol](https://modelcontextprotocol.com/) server that provid
 - Get specific tests that validate each security control
 - Understand which automated tests monitor compliance for specific controls
 
+### People Management
+
+- Access all personnel in your Vanta account including employees, contractors, and other team members
+- View essential employee information like names, email addresses, employment status, and compliance task progress
+- Optimized responses with filtered data to reduce payload size for better performance
+
 ### Multi-Region Support
 
 - US, EU, and AUS regions with region-specific API endpoints

--- a/src/eval/eval.ts
+++ b/src/eval/eval.ts
@@ -9,6 +9,7 @@ import {
   GetControlsTool,
   GetControlTestsTool,
 } from "../operations/controls.js";
+import { GetPeopleTool } from "../operations/people.js";
 
 // Format all tools for OpenAI
 const tools = [
@@ -58,6 +59,14 @@ const tools = [
       name: GetControlTestsTool.name,
       description: GetControlTestsTool.description,
       parameters: zodToJsonSchema(GetControlTestsTool.parameters),
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: GetPeopleTool.name,
+      description: GetPeopleTool.description,
+      parameters: zodToJsonSchema(GetPeopleTool.parameters),
     },
   },
 ];
@@ -126,6 +135,18 @@ const testCases: TestCase[] = [
     expectedTool: "get_control_tests",
     expectedParams: { controlId: "access-control-1" },
     description: "Should call get_control_tests for specific control",
+  },
+  {
+    prompt: "Who are all the people in my vanta organization?",
+    expectedTool: "get_people",
+    expectedParams: {},
+    description: "Should call get_people to list all personnel",
+  },
+  {
+    prompt: "Show me a list of employees and contractors in my Vanta account",
+    expectedTool: "get_people",
+    expectedParams: {},
+    description: "Should call get_people for personnel management",
   },
   {
     prompt: "What programming tests should I write for my API?",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ import {
   getControls,
   getControlTests,
 } from "./operations/controls.js";
+import {
+  GetPeopleTool,
+  getPeople,
+} from "./operations/people.js";
 import { initializeToken } from "./auth.js";
 
 const server = new McpServer({
@@ -69,6 +73,13 @@ server.tool(
   GetControlTestsTool.description,
   GetControlTestsTool.parameters.shape,
   getControlTests,
+);
+
+server.tool(
+  GetPeopleTool.name,
+  GetPeopleTool.description,
+  GetPeopleTool.parameters.shape,
+  getPeople,
 );
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,7 @@ import {
   getControls,
   getControlTests,
 } from "./operations/controls.js";
-import {
-  GetPeopleTool,
-  getPeople,
-} from "./operations/people.js";
+import { GetPeopleTool, getPeople } from "./operations/people.js";
 import { initializeToken } from "./auth.js";
 
 const server = new McpServer({

--- a/src/operations/people.ts
+++ b/src/operations/people.ts
@@ -1,0 +1,70 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { baseApiUrl } from "../api.js";
+import { Tool } from "../types.js";
+import { z } from "zod";
+import { makeAuthenticatedRequest } from "./utils.js";
+
+const GetPeopleInput = z.object({
+  pageSize: z
+    .number()
+    .describe("Number of people to return (1-100, default 10)")
+    .optional(),
+  pageCursor: z.string().describe("Pagination cursor for next page").optional(),
+});
+
+export const GetPeopleTool: Tool<typeof GetPeopleInput> = {
+  name: "get_people",
+  description:
+    "Returns a list of all people in your Vanta account. This includes employees, contractors, and other personnel who have access to your organization's systems and data. Use this to get information about team members for compliance and security management purposes. Note: The response is filtered to exclude detailed source information and task details to reduce payload size.",
+  parameters: GetPeopleInput,
+};
+
+export async function getPeople(
+  args: z.infer<typeof GetPeopleInput>,
+): Promise<CallToolResult> {
+  const url = new URL("/v1/people", baseApiUrl());
+
+  if (args.pageSize !== undefined) {
+    url.searchParams.append("pageSize", args.pageSize.toString());
+  }
+  if (args.pageCursor !== undefined) {
+    url.searchParams.append("pageCursor", args.pageCursor);
+  }
+
+  const response = await makeAuthenticatedRequest(url.toString());
+
+  if (!response.ok) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Error: ${response.statusText}`,
+        },
+      ],
+    };
+  }
+
+  const data = await response.json();
+  
+  // Filter out large/unnecessary fields from the response
+  if (data.results && data.results.data && Array.isArray(data.results.data)) {
+    data.results.data = data.results.data.map((person: any) => {
+      // Remove sources field
+      const { sources, ...personWithoutSources } = person;
+      
+      // Remove tasksSummary.details field while keeping the rest of tasksSummary
+      if (personWithoutSources.tasksSummary && personWithoutSources.tasksSummary.details) {
+        const { details, ...tasksSummaryWithoutDetails } = personWithoutSources.tasksSummary;
+        personWithoutSources.tasksSummary = tasksSummaryWithoutDetails;
+      }
+      
+      return personWithoutSources;
+    });
+  }
+
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(data) },
+    ],
+  };
+} 

--- a/src/operations/people.ts
+++ b/src/operations/people.ts
@@ -44,27 +44,30 @@ export async function getPeople(
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const data = await response.json();
-  
+
   // Filter out large/unnecessary fields from the response
-  if (data.results && data.results.data && Array.isArray(data.results.data)) {
+  if (Array.isArray(data?.results?.data)) {
     data.results.data = data.results.data.map((person: any) => {
       // Remove sources field
-      const { sources, ...personWithoutSources } = person;
-      
+      const { sources: _, ...personWithoutSources } = person;
+
       // Remove tasksSummary.details field while keeping the rest of tasksSummary
-      if (personWithoutSources.tasksSummary && personWithoutSources.tasksSummary.details) {
-        const { details, ...tasksSummaryWithoutDetails } = personWithoutSources.tasksSummary;
+      if (
+        personWithoutSources.tasksSummary &&
+        personWithoutSources.tasksSummary.details
+      ) {
+        const { details: _, ...tasksSummaryWithoutDetails } =
+          personWithoutSources.tasksSummary;
         personWithoutSources.tasksSummary = tasksSummaryWithoutDetails;
       }
-      
+
       return personWithoutSources;
     });
   }
 
   return {
-    content: [
-      { type: "text" as const, text: JSON.stringify(data) },
-    ],
+    content: [{ type: "text" as const, text: JSON.stringify(data) }],
   };
-} 
+}


### PR DESCRIPTION
 - Add new people operations module (src/operations/people.ts)
 - Implement get_people MCP tool with pagination support
 - Filter out large fields (sources, tasksSummary.details) to reduce payload size
 - Register tool in main server and update documentation